### PR TITLE
Include img tags with a src

### DIFF
--- a/src/scorer.rs
+++ b/src/scorer.rs
@@ -302,7 +302,7 @@ pub fn clean(mut dom: &mut RcDom, id: &Path, handle: Handle, url: &Url, candidat
                 "form" | "table" | "ul" | "div" => {
                     useless = is_useless(id, handle.clone(), candidates)
                 },
-                "img" => useless = fix_img_path(handle.clone(), url),
+                "img" => useless = !fix_img_path(handle.clone(), url),
                 _     => (),
             }
             dom::clean_attr("id"   , &mut *attrs.borrow_mut());


### PR DESCRIPTION
I noticed that no images were being included.  I think they should only be marked useless if we can NOT resolve the image src.