### PR TITLE
Update dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ keywords = ["readability"]
 categories = []
 
 [dependencies]
-regex            = "^0.2"
-url              = "1.6"
-html5ever        = "^0.22.0"
+regex            = "1"
+url              = "1"
+html5ever        = "0.22"
 lazy_static      = "1.0"
 
 [dependencies.reqwest]
-version = "0.8"
+version = "0.9"
 optional = true
 
 [features]


### PR DESCRIPTION
Hey, so I've been testing with this crate, and it is currently broken, as it does not find openssl on some machines (mine is one of them, using Arch Linux).

So I updated the dependencies, and everything works fine with the new version.