### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "readability"
-version = "0.1.4"
+name = "readability-fork"
+version = "0.2.0"
 authors = ["Hiroki Kumamoto <kumabook@live.jp>"]
 license = "MIT"
-homepage = "https://github.com/kumabook/readability"
-repository = "https://github.com/kumabook/readability.git"
-description = "Port of arc90's readability project to rust"
+homepage = "https://github.com/jangernert/readability"
+repository = "https://github.com/jangernert/readability.git"
+description = "Temporary fork of 'readability' crate with updated dependencies"
 keywords = ["readability"]
 categories = []
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readability-fork"
-version = "0.2.0"
+version = "0.2.1-alpha.0"
 authors = ["Hiroki Kumamoto <kumabook@live.jp>"]
 license = "MIT"
 homepage = "https://github.com/jangernert/readability"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,16 @@ repository = "https://github.com/kumabook/readability.git"
 description = "Port of arc90's readability project to rust"
 keywords = ["readability"]
 categories = []
+edition = "2018"
 
 [dependencies]
 regex            = "1"
-url              = "1"
-html5ever        = "0.22"
-lazy_static      = "1.0"
+url              = "2.1"
+html5ever        = "0.24"
+lazy_static      = "1.4"
 
 [dependencies.reqwest]
-version = "0.9"
+version = "0.10"
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readability-fork"
-version = "0.2.1"
+version = "0.2.2-alpha.0"
 authors = ["Hiroki Kumamoto <kumabook@live.jp>"]
 license = "MIT"
 homepage = "https://github.com/jangernert/readability"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readability-fork"
-version = "0.2.1-alpha.0"
+version = "0.2.1"
 authors = ["Hiroki Kumamoto <kumabook@live.jp>"]
 license = "MIT"
 homepage = "https://github.com/jangernert/readability"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ readability = "^0"
 
 ```rust
 
-extern crate readability;
 use readability::extractor;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,3 @@
-#[macro_use]
-extern crate html5ever;
-extern crate regex;
-extern crate url;
-#[macro_use]
-extern crate lazy_static;
-#[cfg(feature = "reqwest")]
-extern crate reqwest;
-
 pub mod extractor;
 pub mod scorer;
 pub mod dom;

--- a/src/scorer.rs
+++ b/src/scorer.rs
@@ -17,7 +17,7 @@ use html5ever::rcdom::NodeData::{
 use html5ever:: rcdom::RcDom;
 use html5ever::{QualName, LocalName};
 use html5ever::tree_builder::{NodeOrText, ElementFlags};
-use dom;
+use crate::dom;
 
 pub static PUNCTUATIONS_REGEX: &'static str = r"([、。，．！？]|\.[^A-Za-z0-9]|,[^0-9]|!|\?)";
 pub static UNLIKELY_CANDIDATES: &'static str =

--- a/src/scorer.rs
+++ b/src/scorer.rs
@@ -4,6 +4,7 @@ use std::cell::Cell;
 use std::collections::BTreeMap;
 use url::Url;
 use regex::Regex;
+use lazy_static::lazy_static;
 use html5ever::tree_builder::TreeSink;
 use html5ever::rcdom::Node;
 use html5ever::rcdom::NodeData::{Element, Text};
@@ -17,6 +18,7 @@ use html5ever::rcdom::NodeData::{
 use html5ever:: rcdom::RcDom;
 use html5ever::{QualName, LocalName};
 use html5ever::tree_builder::{NodeOrText, ElementFlags};
+use html5ever::{ns, namespace_url};
 use crate::dom;
 
 pub static PUNCTUATIONS_REGEX: &'static str = r"([、。，．！？]|\.[^A-Za-z0-9]|,[^0-9]|!|\?)";

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,4 @@
-extern crate readability;
-extern crate url;
-
+use readability_fork;
 use std::fs::File;
 use url::Url;
 
@@ -9,6 +7,6 @@ fn test_extract_title() {
     assert!(true);
     let mut file = File::open("./data/title.html").unwrap();
     let url = Url::parse("https://example.com").unwrap();
-    let product = readability::extractor::extract(&mut file, &url).unwrap();
+    let product = readability_fork::extractor::extract(&mut file, &url).unwrap();
     assert_eq!(product.title, "This is title");
 }


### PR DESCRIPTION
- update url, reqwest, lazy_static to newest versions
- update html5ever to 0.24.1 as the latest 0.25 breaks the API
- update to rust 2018
- make scrape async and use async client for downloading
- add a method to pass the reqwest client to use (to ensure clients are configured the same way across an application)