### PR TITLE
make href links absolute and fix a bug with image absolute links

### DIFF
--- a/data/img.html
+++ b/data/img.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>This is title</title>
+  </head>
+  <body>
+    <p> <img src="poop.png" /> </p>
+  </body>
+</html>

--- a/data/rel.html
+++ b/data/rel.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>This is title</title>
+  </head>
+  <body>
+    <p> <a href="poop"> poop </a> </p>
+  </body>
+</html>

--- a/src/scorer.rs
+++ b/src/scorer.rs
@@ -58,9 +58,24 @@ pub fn fix_img_path(handle: Handle, url: &Url) -> bool {
         return false
     }
     let s = src.unwrap();
-    if !s.starts_with("//") && !s.starts_with("http://") && s.starts_with("https://") {
+    if !s.starts_with("//") && !s.starts_with("http://") && !s.starts_with("https://") {
         match url.join(&s) {
             Ok(new_url) => dom::set_attr("src", new_url.as_str(), handle),
+            Err(_)      => (),
+        }
+    }
+    true
+}
+
+pub fn fix_anchor_path(handle: Handle, url: &Url) -> bool {
+    let src = dom::get_attr("href", handle.clone());
+    if src.is_none() {
+        return false
+    }
+    let s = src.unwrap();
+    if !s.starts_with("//") && !s.starts_with("http://") && !s.starts_with("https://") {
+        match url.join(&s) {
+            Ok(new_url) => dom::set_attr("href", new_url.as_str(), handle),
             Err(_)      => (),
         }
     }
@@ -304,6 +319,7 @@ pub fn clean(mut dom: &mut RcDom, id: &Path, handle: Handle, url: &Url, candidat
                     useless = is_useless(id, handle.clone(), candidates)
                 },
                 "img" => useless = !fix_img_path(handle.clone(), url),
+                "a" => useless = !fix_anchor_path(handle.clone(), url),
                 _     => (),
             }
             dom::clean_attr("id"   , &mut *attrs.borrow_mut());

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,3 +12,21 @@ fn test_extract_title() {
     let product = readability::extractor::extract(&mut file, &url).unwrap();
     assert_eq!(product.title, "This is title");
 }
+
+#[test]
+fn test_fix_rel_links() {
+    assert!(true);
+    let mut file = File::open("./data/rel.html").unwrap();
+    let url = Url::parse("https://example.com").unwrap();
+    let product = readability::extractor::extract(&mut file, &url).unwrap();
+    assert_eq!(product.content, "<!DOCTYPE html><html><head><title>This is title</title></head><body><p><a href=\"https://example.com/poop\"> poop </a></p></body></html>");
+}
+
+#[test]
+fn test_fix_img_links() {
+    assert!(true);
+    let mut file = File::open("./data/img.html").unwrap();
+    let url = Url::parse("https://example.com").unwrap();
+    let product = readability::extractor::extract(&mut file, &url).unwrap();
+    assert_eq!(product.content, "<!DOCTYPE html><html><head><title>This is title</title></head><body><p><img src=\"https://example.com/poop.png\"></p></body></html>");
+}


### PR DESCRIPTION
We try and do this already for images this extends this behavior to anchor link. 

I also include a logic fix for images and 2 new test case.

Bug Fix:
```rust
if !s.starts_with("//") && !s.starts_with("http://") && s.starts_with("https://") {
```
if img src url is not "//", "http://" BUT IS!! "https://". I believe you meant NOT https or else it doesnt make much sense.