### PR TITLE
fix: use rustls instead of openssl-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ lazy_static = "1.4"
 [dependencies.reqwest]
 version = "0.11"
 optional = true
-features = ["blocking"]
+features = ["blocking", "rustls-tls"]
+default-features = false
 
 [features]
 default = ["reqwest"]


### PR DESCRIPTION
This removes the dependency on openssl, which is not installed by default on many Linux distros.